### PR TITLE
KB1-94: Criar o Radio Component

### DIFF
--- a/app/components/radio_component.html.erb
+++ b/app/components/radio_component.html.erb
@@ -1,0 +1,8 @@
+<div class="flex items-center mb-4">
+    <input id="<%= @id %>" type="radio" value="" name="default-radio" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+    <label for="<%= @id %>" class="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"><%= @label_text %></label>
+</div>
+<div class="flex items-center">
+    <input checked id="<%= @id %>" type="radio" value="" name="default-radio" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+    <label for="<%= @id %>" class="ms-2 text-sm font-medium text-gray-900 dark:text-gray-300"><%= @label_text %></label>
+</div>

--- a/app/components/radio_component.rb
+++ b/app/components/radio_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RadioComponent < ViewComponent::Base
+  def initialize(label_text:, id:)
+    @label_text = label_text
+    @id = id
+  end
+
+end

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -1,3 +1,5 @@
+require 'lookbook'
+
 Lookbook.configure do |config|
   config.preview_layout = 'lookbook'
 end

--- a/test/components/previews/radio_component_preview.rb
+++ b/test/components/previews/radio_component_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RadioComponentPreview < ViewComponent::Preview
+  def default
+    render(RadioComponent.new(label_text: 'label_text', id: 'id'))
+  end
+end

--- a/test/components/radio_component_test.rb
+++ b/test/components/radio_component_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RadioComponentTest < ViewComponent::TestCase
+  def test_component_renders_something_useful
+    # assert_equal(
+    #   %(<span>Hello, components!</span>),
+    #   render_inline(RadioComponent.new(message: "Hello, components!")).css("span").to_html
+    # )
+  end
+
+  def test_rendering_with_default_values
+    # sets necessary data/state:
+    label_text = "Example Label"
+    id = "radio1"
+
+    # acts: renders the component
+    rendered_component = render_inline(RadioComponent.new(label_text: label_text, id: id))
+
+    # checks / asserts the component contains expected HTML
+    assert_includes rendered_component.css("input[type='radio']").to_html, "id=\"#{id}\""
+    assert_includes rendered_component.css("label").to_html, label_text
+  end
+
+  def test_checked_radio_button
+    # Arrange
+    label_text = "Checked Radio"
+    id = "checked_radio"
+
+    # Act
+    rendered_component = render_inline(RadioComponent.new(label_text: label_text, id: id))
+
+    # Assert: Ensure one of the radio buttons is pre-checked
+    assert rendered_component.css("input[type='radio'][checked]").present?
+  end
+end


### PR DESCRIPTION
- Adiciona 'requires lookbook' em config/initializers/lookbook;
- Cria radio_component com 'rails g component radio';
- No  arquivo radio_component.rb cria os estados do componente e suas variáveis de instância;
- Em radio_component.html.rb cria o código HTML e Tailwind (fornecido anteriormente) e substituindo placeholders com as variáveis de instância;
- Cria a visualização preview de radio component para o lookbook ;
- Cria testes para o componente